### PR TITLE
Revert to simple Alpaca trading flow

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,3 @@
-EXPO_PUBLIC_BACKEND_URL=https://borb6.onrender.com
 ALPACA_API_KEY=PKN4ICO3WECXSLDGXCHC
 ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
 ALPACA_BASE_URL=https://paper-api.alpaca.markets

--- a/backend/account.js
+++ b/backend/account.js
@@ -1,0 +1,23 @@
+const axios = require('axios');
+
+const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
+const API_KEY = process.env.ALPACA_API_KEY;
+const SECRET_KEY = process.env.ALPACA_SECRET_KEY;
+
+const HEADERS = {
+  'APCA-API-KEY-ID': API_KEY,
+  'APCA-API-SECRET-KEY': SECRET_KEY,
+};
+
+async function getAccountInfo() {
+  const res = await axios.get(`${ALPACA_BASE_URL}/account`, { headers: HEADERS });
+  const portfolioValue = parseFloat(res.data.portfolio_value);
+  const buyingPower = parseFloat(res.data.buying_power);
+  return {
+    portfolioValue: isNaN(portfolioValue) ? 0 : portfolioValue,
+    buyingPower: isNaN(buyingPower) ? 0 : buyingPower,
+  };
+}
+
+module.exports = { getAccountInfo };
+

--- a/backend/trade.js
+++ b/backend/trade.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { getAccountInfo } = require('./account');
 
 const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
 const DATA_URL = 'https://data.alpaca.markets/v1beta2';
@@ -12,66 +13,19 @@ const HEADERS = {
 
 // Offsets taker fees when calculating profit target
 const FEE_BUFFER = 0.0025; // 0.25% taker fee
-const TARGET_PROFIT = 0.0005; // 0.05% desired profit
+const TARGET_PROFIT = 0.005; // 0.5% desired profit
 const TOTAL_MARKUP = FEE_BUFFER + TARGET_PROFIT;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Places a limit buy order first, then a limit sell after the buy is filled.
-async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
-  // submit the limit buy order
-  const buyRes = await axios.post(
-    `${ALPACA_BASE_URL}/orders`,
-    {
-      symbol,
-      qty,
-      side: 'buy',
-      type: 'limit',
-      // crypto orders must be GTC
-      time_in_force: 'gtc',
-      limit_price: limitPrice,
-    },
-    { headers: HEADERS }
-  );
+function roundQty(qty) {
+  return parseFloat(Number(qty).toFixed(8));
+}
 
-  const buyOrder = buyRes.data;
-
-  // poll until the order is filled
-  let filledOrder = buyOrder;
-  for (let i = 0; i < 20; i++) {
-    const check = await axios.get(`${ALPACA_BASE_URL}/orders/${buyOrder.id}`, {
-      headers: HEADERS,
-    });
-    filledOrder = check.data;
-    if (filledOrder.status === 'filled') break;
-    await sleep(3000);
-  }
-
-  if (filledOrder.status !== 'filled') {
-    throw new Error('Buy order not filled in time');
-  }
-
-  const avgPrice = parseFloat(filledOrder.filled_avg_price);
-  // Mark up sell price to cover taker fees and capture desired profit
-  const sellPrice = roundPrice(avgPrice * (1 + TOTAL_MARKUP));
-
-  const sellRes = await axios.post(
-    `${ALPACA_BASE_URL}/orders`,
-    {
-      symbol,
-      qty: filledOrder.filled_qty,
-      side: 'sell',
-      type: 'limit',
-      // match the buy order's time in force
-      time_in_force: 'gtc',
-      limit_price: sellPrice,
-    },
-    { headers: HEADERS }
-  );
-
-  return { buy: filledOrder, sell: sellRes.data };
+function roundPrice(price) {
+  return parseFloat(Number(price).toFixed(2));
 }
 
 // Fetch latest trade price for a symbol
@@ -85,40 +39,15 @@ async function getLatestPrice(symbol) {
   return parseFloat(trade.p);
 }
 
-// Get portfolio value and buying power from the Alpaca account
-async function getAccountInfo() {
-  const res = await axios.get(`${ALPACA_BASE_URL}/account`, { headers: HEADERS });
-  const portfolioValue = parseFloat(res.data.portfolio_value);
-  const buyingPower = parseFloat(res.data.buying_power);
-  return {
-    portfolioValue: isNaN(portfolioValue) ? 0 : portfolioValue,
-    buyingPower: isNaN(buyingPower) ? 0 : buyingPower,
-  };
-}
-
-// Round quantities to Alpaca's supported crypto precision
-function roundQty(qty) {
-  return parseFloat(Number(qty).toFixed(8));
-}
-
-// Round prices to two decimals
-function roundPrice(price) {
-  return parseFloat(Number(price).toFixed(2));
-}
-
-// Market buy using 10% of portfolio value then place a limit sell with markup
-// covering taker fees and profit target
-async function placeMarketBuyThenSell(symbol) {
+// Limit buy using 10% of portfolio value then place a delayed limit sell with markup
+async function placeLimitBuyThenSell(symbol) {
   const [price, account] = await Promise.all([
     getLatestPrice(symbol),
     getAccountInfo(),
   ]);
 
-  const portfolioValue = account.portfolioValue;
-  const buyingPower = account.buyingPower;
-
-  const targetTradeAmount = portfolioValue * 0.1;
-  const amountToSpend = Math.min(targetTradeAmount, buyingPower);
+  const targetTradeAmount = account.portfolioValue * 0.1;
+  const amountToSpend = Math.min(targetTradeAmount, account.buyingPower);
 
   if (amountToSpend < 10) {
     throw new Error('Insufficient buying power for trade');
@@ -135,15 +64,15 @@ async function placeMarketBuyThenSell(symbol) {
       symbol,
       qty,
       side: 'buy',
-      type: 'market',
+      type: 'limit',
       time_in_force: 'gtc',
+      limit_price: price,
     },
     { headers: HEADERS }
   );
 
   const buyOrder = buyRes.data;
 
-  // Wait for fill
   let filled = buyOrder;
   for (let i = 0; i < 20; i++) {
     const chk = await axios.get(`${ALPACA_BASE_URL}/orders/${buyOrder.id}`, {
@@ -161,32 +90,27 @@ async function placeMarketBuyThenSell(symbol) {
   // Wait 10 seconds before selling
   await sleep(10000);
 
-  // Mark up sell price to cover taker fees and preserve desired profit margin
   const limitPrice = roundPrice(
     parseFloat(filled.filled_avg_price) * (1 + TOTAL_MARKUP)
   );
 
-  try {
-    const sellRes = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
-      {
-        symbol,
-        qty: filled.filled_qty,
-        side: 'sell',
-        type: 'limit',
-        time_in_force: 'gtc',
-        limit_price: limitPrice,
-      },
-      { headers: HEADERS }
-    );
-    return { buy: filled, sell: sellRes.data };
-  } catch (err) {
-    console.error('Sell order failed:', err?.response?.data || err.message);
-    return { buy: filled, sell: null, sellError: err.message };
-  }
+  const sellRes = await axios.post(
+    `${ALPACA_BASE_URL}/orders`,
+    {
+      symbol,
+      qty: filled.filled_qty,
+      side: 'sell',
+      type: 'limit',
+      time_in_force: 'gtc',
+      limit_price: limitPrice,
+    },
+    { headers: HEADERS }
+  );
+
+  return { buy: filled, sell: sellRes.data };
 }
 
 module.exports = {
   placeLimitBuyThenSell,
-  placeMarketBuyThenSell,
 };
+

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,5 +1,1 @@
 EXPO_PUBLIC_BACKEND_URL=https://borb6.onrender.com
-ALPACA_API_KEY=PKN4ICO3WECXSLDGXCHC
-ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://paper-api.alpaca.markets
-ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2


### PR DESCRIPTION
## Summary
- Route React Native app through backend via `EXPO_PUBLIC_BACKEND_URL` and place limit buys with delayed limit sells
- Proxy Alpaca API through backend and add dedicated account utility
- Restore environment configs for paper trading endpoints

## Testing
- `npm test` *(fails: Missing script)*
- `(cd frontend && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689284cbe2c88325821c9e72113ebebb