### PR TITLE
Fix Alpaca trade endpoint and account info retrieval

### DIFF
--- a/backend/account.js
+++ b/backend/account.js
@@ -1,24 +1,17 @@
 require('dotenv').config();
 const axios = require('axios');
 
-const ALPACA_BASE_URL = process.env.ALPACA_BASE_URL;
-
-const headers = {
-  'APCA-API-KEY-ID': process.env.ALPACA_API_KEY,
-  'APCA-API-SECRET-KEY': process.env.ALPACA_SECRET_KEY,
-};
-
-// Debug credentials on startup (remove once verified)
-console.log('Alpaca BASE URL:', process.env.ALPACA_BASE_URL);
-console.log('API KEY starts with:', process.env.ALPACA_API_KEY?.slice(0, 5));
-
 async function getAccountInfo() {
-  const res = await axios.get(`${ALPACA_BASE_URL}/v2/account`, { headers });
-  const portfolioValue = parseFloat(res.data.portfolio_value);
-  const buyingPower = parseFloat(res.data.buying_power);
+  const res = await axios.get(`${process.env.ALPACA_BASE_URL}/v2/account`, {
+    headers: {
+      'APCA-API-KEY-ID': process.env.ALPACA_API_KEY,
+      'APCA-API-SECRET-KEY': process.env.ALPACA_SECRET_KEY,
+    },
+  });
+  const data = res.data;
   return {
-    portfolioValue: isNaN(portfolioValue) ? 0 : portfolioValue,
-    buyingPower: isNaN(buyingPower) ? 0 : buyingPower,
+    buyingPower: parseFloat(data.buying_power),
+    portfolioValue: parseFloat(data.portfolio_value),
   };
 }
 


### PR DESCRIPTION
## Summary
- fetch crypto quotes from Alpaca v1beta1 with CoinGecko fallback
- log buy requests for easier debugging
- add account info retrieval with proper headers

## Testing
- `node -e "require('./backend/account').getAccountInfo().then(r=>{console.log('ACCOUNT', r);}).catch(e=>{console.error('ERR', e.response?.data || e.message);})"` *(fails: Domain forbidden)*
- `node -e "require('./backend/trade').placeLimitBuyThenSell('BTCUSD').then(r=>console.log('TRADE', r)).catch(e=>console.error('ERR', e.response?.data || e.message));"` *(fails: Domain forbidden)*
- `cd backend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68929cf752d88325b2e1db3749abb5e7