### PR TITLE
Configure Render deployment for Python backend

### DIFF
--- a/backend/.render-build.sh
+++ b/backend/.render-build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Custom build steps for Render deployment
+set -o errexit
+
+pip install --upgrade pip
+pip install -r requirements.txt

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENV PORT=10000
+EXPOSE 10000
+
+CMD ["python", "app.py"]

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -1,0 +1,16 @@
+services:
+  - type: web
+    name: crypto-backend
+    env: python
+    plan: free
+    rootDir: backend
+    buildCommand: "./.render-build.sh"
+    startCommand: "python app.py"
+    envVars:
+      - key: ALPACA_API_KEY
+        value: YOUR_ALPACA_API_KEY
+      - key: ALPACA_SECRET_KEY
+        value: YOUR_ALPACA_SECRET_KEY
+      - key: ALPACA_BASE_URL
+        value: https://api.alpaca.markets
+    pythonVersion: 3.11


### PR DESCRIPTION
## Summary
- add Render config to deploy backend as Python service
- include Dockerfile for optional container deployment
- provide build script installing dependencies

## Testing
- `python -m py_compile backend/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941459f0d08325a996966bc8561b12