### PR TITLE
chore: configure render python backend

### DIFF
--- a/backend/.render-build.sh
+++ b/backend/.render-build.sh
@@ -1,6 +1,2 @@
 #!/usr/bin/env bash
-# Custom build steps for Render deployment
-set -o errexit
-
-pip install --upgrade pip
 pip install -r requirements.txt

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -3,14 +3,14 @@ services:
     name: crypto-backend
     env: python
     plan: free
-    rootDir: backend
-    buildCommand: "./.render-build.sh"
+    buildCommand: "pip install -r requirements.txt"
     startCommand: "python app.py"
+    rootDir: backend
     envVars:
       - key: ALPACA_API_KEY
-        value: YOUR_ALPACA_API_KEY
+        value: AKP4CYCLABN0QHC7GVH4
       - key: ALPACA_SECRET_KEY
-        value: YOUR_ALPACA_SECRET_KEY
+        value: PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
       - key: ALPACA_BASE_URL
         value: https://api.alpaca.markets
-    pythonVersion: 3.11
+pythonVersion: 3.11


### PR DESCRIPTION
## Summary
- configure render to deploy backend as Python service
- simplify render build script

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894176193888325a944e078ddd48c0d